### PR TITLE
Fix process stuck at validating adaptation set.

### DIFF
--- a/app/controllers/stepperController.js
+++ b/app/controllers/stepperController.js
@@ -957,10 +957,10 @@
                 var Period_count = Periodxml.length;
                 var AdaptRepPeriod_count = Period_count;
                 for (var p = 0; p < Period_count; p++) {
-                    var Adapt_count = Periodxml[p].childNodes.length;
+                    var Adaptxml = Periodxml[p].getElementsByTagName("Adaptation");
+                    var Adapt_count = Adaptxml.length;
                     vm.adaptholder.push(Adapt_count);
                     AdaptRepPeriod_count += ' ' + Adapt_count;
-                    var Adaptxml = Periodxml[p].getElementsByTagName("Adaptation");
                     for (var v = 0; v < Adapt_count; v++) {
                         AdaptRepPeriod_count += " " + Adaptxml[v].getElementsByTagName("Representation").length;
                     }


### PR DESCRIPTION
The DASH-IF validator stuck at process adaptation set due the the Adapt_count not correct.
Adapt_count  should not be Periodxml[p].childNodes.length as there are more nodes other than adaptation count in progress.xml file.
e.g:
```
<Period>
<Adaptation>
... ...
</Adaptation>
<BrokenURL></BrokenURL>
<SelectionSet></SelectionSet>
<CMAFProfile></CMAFProfile>
<CTAWAVESelectionSet></CTAWAVESelectionSet>
<CTAWAVEPresentation></CTAWAVEPresentation>
</Period>
```

Instead Adapt_count should be Adaptation elements count:
```
var Adaptxml = Periodxml[p].getElementsByTagName("Adaptation");
var Adapt_count = Adaptxml.length;
```